### PR TITLE
feat: Compare Apps view for cross-app keyword ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Research ASO keywords, inspect competition, and manage results from one local-fi
 - Fast, free keyword research and visibility tracking
 - Keyword scoring with popularity + difficulty + brand classification in one command
 - Local ASO dashboard for reviewing keyword/app data
+- Compare apps across keywords from the dashboard — pick multiple apps plus a keyword set and see a side-by-side rank matrix (including apps that don't currently track the keyword)
 - MCP tool (`aso_evaluate_keywords`) for agent workflows and automated keyword research
 
 <h3 align="center">ASO Dashboard</h3>

--- a/cli/dashboard-server/routes/aso-routes.ts
+++ b/cli/dashboard-server/routes/aso-routes.ts
@@ -1,4 +1,5 @@
 import { createAppDocHandlers, fetchAsoAppDocsFromApi } from "./app-doc-handlers";
+import { createCompareHandlers } from "./compare-handlers";
 import { createKeywordHandlers } from "./keyword-handlers";
 import type { AsoRouteDeps } from "./aso-route-types";
 
@@ -7,9 +8,11 @@ export { fetchAsoAppDocsFromApi };
 export function createAsoRouteHandlers(deps: AsoRouteDeps) {
   const keywordHandlers = createKeywordHandlers(deps);
   const appDocHandlers = createAppDocHandlers(deps);
+  const compareHandlers = createCompareHandlers(deps);
 
   return {
     ...keywordHandlers,
     ...appDocHandlers,
+    ...compareHandlers,
   };
 }

--- a/cli/dashboard-server/routes/compare-handlers.ts
+++ b/cli/dashboard-server/routes/compare-handlers.ts
@@ -1,0 +1,319 @@
+import * as http from "http";
+import { logger } from "../../utils/logger";
+import { listUnionKeywords, getCompareMatrix } from "../../db/app-compare";
+import { getOwnedAppById } from "../../db/owned-apps";
+import { normalizeCountry } from "../../domain/keywords/policy";
+import {
+  COMPARE_MAX_APPS,
+  COMPARE_MAX_KEYWORDS,
+  COMPARE_MIN_APPS,
+  COMPARE_MIN_KEYWORDS,
+  type CompareApp,
+  type CompareKeywordsResponse,
+  type CompareMatrixResponse,
+} from "../../shared/compare-types";
+import type { AsoRouteDeps } from "./aso-route-types";
+
+function parseAppIdsQueryParam(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function resolveApps(
+  appIds: string[],
+  country: string
+): { resolved: CompareApp[]; missing: string[] } {
+  const resolved: CompareApp[] = [];
+  const missing: string[] = [];
+  for (const appId of appIds) {
+    const app = getOwnedAppById(appId, country);
+    if (!app) {
+      missing.push(appId);
+      continue;
+    }
+    resolved.push({ appId: app.id, name: app.name });
+  }
+  return { resolved, missing };
+}
+
+export function createCompareHandlers(deps: AsoRouteDeps) {
+  function handleCompareKeywordsGet(
+    res: http.ServerResponse,
+    query: Record<string, string>
+  ): void {
+    const country = normalizeCountry(query.country);
+    const appIds = dedupe(parseAppIdsQueryParam(query.appIds));
+
+    if (appIds.length < COMPARE_MIN_APPS) {
+      deps.sendApiError(
+        res,
+        400,
+        "INVALID_REQUEST",
+        `Please provide at least ${COMPARE_MIN_APPS} app IDs.`
+      );
+      return;
+    }
+    if (appIds.length > COMPARE_MAX_APPS) {
+      deps.sendApiError(
+        res,
+        413,
+        "TOO_MANY_APPS",
+        `A maximum of ${COMPARE_MAX_APPS} apps can be compared at once.`
+      );
+      return;
+    }
+
+    const { resolved, missing } = resolveApps(appIds, country);
+    if (missing.length > 0) {
+      deps.sendApiError(
+        res,
+        404,
+        "APP_NOT_FOUND",
+        `Unknown app IDs: ${missing.join(", ")}`
+      );
+      return;
+    }
+
+    try {
+      const rows = listUnionKeywords(appIds, country);
+      const response: CompareKeywordsResponse = {
+        country,
+        apps: resolved,
+        keywords: rows.map((row) => ({
+          keyword: row.keyword,
+          normalizedKeyword: row.normalizedKeyword,
+          trackedByAppIds: row.trackedByAppIds,
+          trackedCount: row.trackedCount,
+          popularity: row.popularity,
+          difficulty: row.difficulty,
+          isResearched: row.isResearched,
+        })),
+      };
+      logger.debug("[aso-dashboard] request", {
+        method: "GET",
+        path: "/api/aso/compare/keywords",
+        country,
+        appCount: appIds.length,
+        keywordCount: rows.length,
+      });
+      deps.sendJson(res, 200, { success: true, data: response });
+    } catch (error) {
+      deps.reportDashboardError(error, {
+        method: "GET",
+        path: "/api/aso/compare/keywords",
+        country,
+        appIds,
+      });
+      const publicError = deps.toUserSafeError(
+        error,
+        "Failed to load compare keyword universe"
+      );
+      deps.sendApiError(
+        res,
+        deps.statusForDashboardErrorCode(publicError.errorCode),
+        publicError.errorCode,
+        publicError.message
+      );
+    }
+  }
+
+  async function handleCompareMatrixPost(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    const body = await deps.parseJsonBody<{
+      appIds?: string[];
+      keywords?: string[];
+      country?: string;
+    }>(req, res);
+    if (!body) {
+      return;
+    }
+
+    const country = normalizeCountry(body.country);
+    const appIds = dedupe(
+      (body.appIds ?? [])
+        .map((value) => (typeof value === "string" ? value.trim() : ""))
+        .filter((value): value is string => value.length > 0)
+    );
+    const keywords = (body.keywords ?? []).filter(
+      (value): value is string => typeof value === "string" && value.trim() !== ""
+    );
+
+    if (appIds.length < COMPARE_MIN_APPS) {
+      deps.sendApiError(
+        res,
+        400,
+        "INVALID_REQUEST",
+        `Please provide at least ${COMPARE_MIN_APPS} app IDs.`
+      );
+      return;
+    }
+    if (appIds.length > COMPARE_MAX_APPS) {
+      deps.sendApiError(
+        res,
+        413,
+        "TOO_MANY_APPS",
+        `A maximum of ${COMPARE_MAX_APPS} apps can be compared at once.`
+      );
+      return;
+    }
+    if (keywords.length < COMPARE_MIN_KEYWORDS) {
+      deps.sendApiError(
+        res,
+        400,
+        "INVALID_REQUEST",
+        `Please provide at least ${COMPARE_MIN_KEYWORDS} keyword.`
+      );
+      return;
+    }
+    if (keywords.length > COMPARE_MAX_KEYWORDS) {
+      deps.sendApiError(
+        res,
+        413,
+        "TOO_MANY_KEYWORDS",
+        `A maximum of ${COMPARE_MAX_KEYWORDS} keywords can be compared at once.`
+      );
+      return;
+    }
+
+    const { resolved, missing } = resolveApps(appIds, country);
+    if (missing.length > 0) {
+      deps.sendApiError(
+        res,
+        404,
+        "APP_NOT_FOUND",
+        `Unknown app IDs: ${missing.join(", ")}`
+      );
+      return;
+    }
+
+    try {
+      const flatRows = getCompareMatrix(appIds, keywords, country);
+      const rowMap = new Map<
+        string,
+        {
+          keyword: string;
+          normalizedKeyword: string;
+          popularity: number | null;
+          difficulty: number | null;
+          isResearched: boolean;
+          cells: Map<
+            string,
+            {
+              currentPosition: number | null;
+              previousPosition: number | null;
+              isTracked: boolean;
+            }
+          >;
+        }
+      >();
+      for (const row of flatRows) {
+        const existing = rowMap.get(row.normalizedKeyword);
+        if (existing) {
+          existing.cells.set(row.appId, {
+            currentPosition: row.currentPosition,
+            previousPosition: row.previousPosition,
+            isTracked: row.isTracked,
+          });
+          continue;
+        }
+        const cells = new Map<
+          string,
+          {
+            currentPosition: number | null;
+            previousPosition: number | null;
+            isTracked: boolean;
+          }
+        >();
+        cells.set(row.appId, {
+          currentPosition: row.currentPosition,
+          previousPosition: row.previousPosition,
+          isTracked: row.isTracked,
+        });
+        rowMap.set(row.normalizedKeyword, {
+          keyword: row.keyword,
+          normalizedKeyword: row.normalizedKeyword,
+          popularity: row.popularity,
+          difficulty: row.difficulty,
+          isResearched: row.isResearched,
+          cells,
+        });
+      }
+
+      const response: CompareMatrixResponse = {
+        country,
+        generatedAt: new Date().toISOString(),
+        apps: resolved,
+        rows: Array.from(rowMap.values()).map((row) => ({
+          keyword: row.keyword,
+          normalizedKeyword: row.normalizedKeyword,
+          popularity: row.popularity,
+          difficulty: row.difficulty,
+          status: row.isResearched ? "researched" : "not_researched",
+          cells: appIds.map((appId) => {
+            const cell = row.cells.get(appId);
+            const currentPosition = cell?.currentPosition ?? null;
+            const previousPosition = cell?.previousPosition ?? null;
+            const change =
+              currentPosition != null && previousPosition != null
+                ? previousPosition - currentPosition
+                : null;
+            return {
+              appId,
+              currentPosition,
+              previousPosition,
+              change,
+              isTracked: cell?.isTracked ?? false,
+            };
+          }),
+        })),
+      };
+      logger.debug("[aso-dashboard] request", {
+        method: "POST",
+        path: "/api/aso/compare/matrix",
+        country,
+        appCount: appIds.length,
+        keywordCount: response.rows.length,
+      });
+      deps.sendJson(res, 200, { success: true, data: response });
+    } catch (error) {
+      deps.reportDashboardError(error, {
+        method: "POST",
+        path: "/api/aso/compare/matrix",
+        country,
+        appIds,
+        keywordCount: keywords.length,
+      });
+      const publicError = deps.toUserSafeError(
+        error,
+        "Failed to load compare matrix"
+      );
+      deps.sendApiError(
+        res,
+        deps.statusForDashboardErrorCode(publicError.errorCode),
+        publicError.errorCode,
+        publicError.message
+      );
+    }
+  }
+
+  return {
+    handleCompareKeywordsGet,
+    handleCompareMatrixPost,
+  };
+}

--- a/cli/dashboard-server/server.ts
+++ b/cli/dashboard-server/server.ts
@@ -411,6 +411,16 @@ export function createServerRequestHandler(): http.RequestListener {
         return;
       }
 
+      if (req.method === "GET" && pathname === "/api/aso/compare/keywords") {
+        asoRouteHandlers.handleCompareKeywordsGet(res, query);
+        return;
+      }
+
+      if (req.method === "POST" && pathname === "/api/aso/compare/matrix") {
+        await asoRouteHandlers.handleCompareMatrixPost(req, res);
+        return;
+      }
+
       if (req.method === "GET" && pathname && !pathname.startsWith("/api/")) {
         const staticPath = resolveStaticPath(DASHBOARD_PUBLIC_DIR, pathname);
         if (staticPath && staticFileExists(staticPath)) {

--- a/cli/dashboard-ui/App.tsx
+++ b/cli/dashboard-ui/App.tsx
@@ -34,6 +34,7 @@ import { AuthDialog } from "./components/auth-dialog";
 import { KeywordActionMenu } from "./components/keyword-action-menu";
 import { AddAppDialog } from "./components/add-app-dialog";
 import { AppActionMenu } from "./components/app-action-menu";
+import { CompareView } from "./components/CompareView";
 import {
   DASHBOARD_FILTER_DEFAULTS,
   DASHBOARD_FILTER_OPTIONS,
@@ -304,6 +305,7 @@ export function App() {
   const [openFilterMenu, setOpenFilterMenu] = useState<FilterMenuKey | null>(null);
   const [keywordActionMenu, setKeywordActionMenu] = useState<KeywordActionMenuState | null>(null);
   const [appActionMenu, setAppActionMenu] = useState<AppActionMenuState | null>(null);
+  const [compareOpen, setCompareOpen] = useState(false);
   const [researchSectionCollapsed, setResearchSectionCollapsed] = useState(false);
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -1797,7 +1799,28 @@ export function App() {
           </section>
 
           <section className="apps-section">
-            <p className="apps-section-title">Apps</p>
+            <div className="apps-section-header">
+              <p className="apps-section-title">Apps</p>
+              <Button
+                id="compare-apps-toggle-sidebar"
+                className="apps-section-compare"
+                variant={compareOpen ? "primary" : "ghost"}
+                size="sm"
+                type="button"
+                disabled={ownedApps.length < 2}
+                title={
+                  ownedApps.length < 2
+                    ? "Add at least 2 apps to compare"
+                    : compareOpen
+                      ? "Exit compare mode"
+                      : "Compare rank across apps"
+                }
+                aria-pressed={compareOpen}
+                onClick={() => setCompareOpen((value) => !value)}
+              >
+                {compareOpen ? "Exit" : "Compare"}
+              </Button>
+            </div>
             {ownedApps.map((app) => {
               const isSelected = selectedAppId === app.id;
               const iconUrl = getIconUrl({
@@ -2071,6 +2094,17 @@ export function App() {
           ) : null}
         </Card>
 
+        {compareOpen ? (
+          <CompareView
+            apps={apps
+              .filter((app) => app.kind === "owned")
+              .map((app) => ({ id: app.id, name: app.name, icon: app.icon }))}
+            currentAppId={selectedAppId}
+            country={DEFAULT_ASO_COUNTRY}
+            initialKeywords={filteredRows.map((row) => row.keyword)}
+            onExit={() => setCompareOpen(false)}
+          />
+        ) : (
         <Card className="table-card">
           <div className="table-wrap">
             <table>
@@ -2327,6 +2361,7 @@ export function App() {
             </p>
           ) : null}
         </Card>
+        )}
       </main>
       {keywordActionMenu ? (
         <KeywordActionMenu

--- a/cli/dashboard-ui/components/CompareView.tsx
+++ b/cli/dashboard-ui/components/CompareView.tsx
@@ -1,0 +1,786 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Badge, Button, Card, Input } from "../ui-react";
+import { cx } from "../ui-react/primitives";
+import { getIconUrl } from "../app-helpers";
+import {
+  COMPARE_MAX_APPS,
+  COMPARE_MAX_KEYWORDS,
+  COMPARE_MIN_APPS,
+} from "../../shared/compare-types";
+import type {
+  CompareMatrixCell,
+  CompareMatrixResponse,
+  CompareMatrixRow,
+  CompareUniverseKeyword,
+} from "../../shared/compare-types";
+import {
+  loadPersistedCompareState,
+  persistCompareState,
+  useCompareMatrix,
+  useCompareSort,
+  useCompareUniverse,
+  useSortedMatrixRows,
+} from "../hooks/use-compare";
+import type { CompareSort } from "../hooks/use-compare";
+
+type AppItem = {
+  id: string;
+  name: string;
+  icon?: Record<string, unknown>;
+};
+
+type CompareViewProps = {
+  apps: AppItem[];
+  currentAppId: string | null;
+  country: string;
+  initialKeywords?: string[];
+  onExit: () => void;
+};
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function formatRank(value: number | null): string {
+  if (value == null) return "";
+  return String(value);
+}
+
+function rankTintClass(currentPosition: number | null): string {
+  if (currentPosition == null) return "";
+  if (currentPosition <= 10) return "compare-cell--tier-top";
+  if (currentPosition <= 50) return "compare-cell--tier-high";
+  if (currentPosition <= 100) return "compare-cell--tier-mid";
+  return "";
+}
+
+function describeCell(cell: CompareMatrixCell, isResearched: boolean): string {
+  if (!isResearched) return "No data — keyword has not been researched yet";
+  if (cell.currentPosition == null && !cell.isTracked)
+    return "Outside top 200 (and app does not track this keyword)";
+  if (cell.currentPosition == null) return "Outside top 200";
+  const suffix = cell.isTracked ? " (tracked by this app)" : "";
+  if (cell.change == null) return `Rank ${cell.currentPosition}${suffix}`;
+  const changeLabel =
+    cell.change > 0
+      ? `up ${cell.change}`
+      : cell.change < 0
+        ? `down ${Math.abs(cell.change)}`
+        : "no change";
+  return `Rank ${cell.currentPosition}, ${changeLabel}${suffix}`;
+}
+
+function CompareCellContent({
+  cell,
+  row,
+}: {
+  cell: CompareMatrixCell;
+  row: CompareMatrixRow;
+}) {
+  if (row.status === "not_researched") {
+    return (
+      <div className="compare-cell-inner compare-cell--pending">
+        <span className="compare-cell-mark" aria-hidden="true">
+          ·
+        </span>
+      </div>
+    );
+  }
+  if (cell.currentPosition == null) {
+    return (
+      <div
+        className={cx(
+          "compare-cell-inner compare-cell--empty",
+          !cell.isTracked && "compare-cell--untracked"
+        )}
+      >
+        <span className="compare-cell-mark" aria-hidden="true">
+          —
+        </span>
+      </div>
+    );
+  }
+  const changeLabel =
+    cell.change == null
+      ? null
+      : cell.change > 0
+        ? `▲ ${cell.change}`
+        : cell.change < 0
+          ? `▼ ${Math.abs(cell.change)}`
+          : "—";
+  return (
+    <div className="compare-cell-inner">
+      <span className="compare-cell-rank">{formatRank(cell.currentPosition)}</span>
+      {changeLabel ? (
+        <span
+          className={cx(
+            "compare-cell-change",
+            cell.change != null && cell.change > 0 && "compare-cell-change--up",
+            cell.change != null && cell.change < 0 && "compare-cell-change--down"
+          )}
+        >
+          {changeLabel}
+        </span>
+      ) : null}
+      {cell.isTracked ? (
+        <span
+          className="compare-cell-tracked-dot"
+          aria-label="Tracked by this app"
+          title="Tracked by this app"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function CompareView({
+  apps,
+  currentAppId,
+  country,
+  initialKeywords = [],
+  onExit,
+}: CompareViewProps) {
+  const persisted = useMemo(() => loadPersistedCompareState(), []);
+  const ownedAppIdSet = useMemo(
+    () => new Set(apps.map((app) => app.id)),
+    [apps]
+  );
+  const initialAppIds = useMemo(() => {
+    if (persisted) {
+      const filtered = persisted.appIds.filter((id) => ownedAppIdSet.has(id));
+      if (filtered.length >= COMPARE_MIN_APPS) return filtered;
+    }
+    const seeded: string[] = [];
+    if (currentAppId && ownedAppIdSet.has(currentAppId)) {
+      seeded.push(currentAppId);
+    }
+    for (const app of apps) {
+      if (seeded.length >= COMPARE_MIN_APPS) break;
+      if (!seeded.includes(app.id)) seeded.push(app.id);
+    }
+    return seeded;
+  }, [persisted, ownedAppIdSet, currentAppId, apps]);
+
+  const [selectedAppIds, setSelectedAppIds] = useState<string[]>(initialAppIds);
+  const [selectedKeywords, setSelectedKeywords] = useState<string[]>(() => {
+    if (persisted && persisted.keywords.length > 0) return persisted.keywords;
+    if (initialKeywords.length > 0)
+      return initialKeywords.slice(0, COMPARE_MAX_KEYWORDS);
+    return [];
+  });
+  const [appPickerOpen, setAppPickerOpen] = useState(false);
+  const [keywordSearch, setKeywordSearch] = useState("");
+  const [showAllKeywords, setShowAllKeywords] = useState(false);
+  const [isMatrixFullscreen, setIsMatrixFullscreen] = useState(false);
+  const appPickerRef = useRef<HTMLDivElement | null>(null);
+
+  const { sort, setSort, toggleSort } = useCompareSort(persisted?.sortBy);
+
+  const enabled = selectedAppIds.length >= COMPARE_MIN_APPS;
+
+  const { universe, isUniverseLoading, universeError } = useCompareUniverse(
+    selectedAppIds,
+    country,
+    enabled
+  );
+
+  useEffect(() => {
+    if (!universe) return;
+    if (selectedKeywords.length > 0) return;
+    if (initialKeywords.length > 0) return;
+    const appIdsSeed = selectedAppIds.slice();
+    const firstAppId = currentAppId ?? appIdsSeed[0];
+    if (!firstAppId) return;
+    const seedKeywords = universe.keywords
+      .filter((kw) => kw.trackedByAppIds.includes(firstAppId))
+      .map((kw) => kw.keyword)
+      .slice(0, 25);
+    if (seedKeywords.length === 0) {
+      const fallback = universe.keywords
+        .slice(0, 10)
+        .map((kw) => kw.keyword);
+      if (fallback.length === 0) return;
+      setSelectedKeywords(fallback);
+      return;
+    }
+    setSelectedKeywords(seedKeywords);
+  }, [universe, selectedKeywords.length, initialKeywords.length, currentAppId, selectedAppIds.join(",")]);
+
+  const { matrix, isMatrixLoading, matrixError } = useCompareMatrix(
+    selectedAppIds,
+    selectedKeywords,
+    country,
+    enabled
+  );
+
+  useEffect(() => {
+    if (selectedAppIds.length < COMPARE_MIN_APPS) return;
+    persistCompareState({
+      appIds: selectedAppIds,
+      keywords: selectedKeywords,
+      sortBy: sort,
+      country,
+    });
+  }, [selectedAppIds.join(","), selectedKeywords.join(","), sort, country]);
+
+  useEffect(() => {
+    if (!appPickerOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!appPickerRef.current) return;
+      if (!(event.target instanceof Node)) return;
+      if (appPickerRef.current.contains(event.target)) return;
+      setAppPickerOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [appPickerOpen]);
+
+  useEffect(() => {
+    if (!isMatrixFullscreen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsMatrixFullscreen(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [isMatrixFullscreen]);
+
+  const appById = useMemo(() => {
+    const map = new Map<string, AppItem>();
+    for (const app of apps) map.set(app.id, app);
+    return map;
+  }, [apps]);
+
+  const selectedApps = useMemo(
+    () =>
+      selectedAppIds
+        .map((id) => appById.get(id))
+        .filter((app): app is AppItem => Boolean(app)),
+    [selectedAppIds, appById]
+  );
+
+  const universeById = useMemo(() => {
+    const map = new Map<string, CompareUniverseKeyword>();
+    if (!universe) return map;
+    for (const keyword of universe.keywords) {
+      map.set(keyword.keyword, keyword);
+    }
+    return map;
+  }, [universe]);
+
+  const filteredUniverseKeywords = useMemo(() => {
+    if (!universe) return [] as CompareUniverseKeyword[];
+    const term = keywordSearch.trim().toLowerCase();
+    let keywords = universe.keywords;
+    if (term) {
+      keywords = keywords.filter((kw) =>
+        kw.keyword.toLowerCase().includes(term)
+      );
+    }
+    if (!showAllKeywords) {
+      keywords = keywords.filter(
+        (kw) => kw.trackedCount >= selectedAppIds.length
+      );
+      if (keywords.length === 0) {
+        keywords = universe.keywords.filter((kw) =>
+          term ? kw.keyword.toLowerCase().includes(term) : true
+        );
+      }
+    }
+    return keywords;
+  }, [universe, keywordSearch, showAllKeywords, selectedAppIds.length]);
+
+  const selectedKeywordSet = useMemo(
+    () => new Set(selectedKeywords),
+    [selectedKeywords]
+  );
+
+  const sortedRows = useSortedMatrixRows(matrix, sort);
+
+  const canAddMoreApps = selectedAppIds.length < COMPARE_MAX_APPS;
+  const canAddMoreKeywords = selectedKeywords.length < COMPARE_MAX_KEYWORDS;
+
+  const handleToggleApp = useCallback(
+    (appId: string) => {
+      setSelectedAppIds((current) => {
+        if (current.includes(appId)) {
+          const next = current.filter((id) => id !== appId);
+          return next;
+        }
+        if (current.length >= COMPARE_MAX_APPS) return current;
+        return [...current, appId];
+      });
+    },
+    []
+  );
+
+  const handleRemoveApp = useCallback((appId: string) => {
+    setSelectedAppIds((current) => current.filter((id) => id !== appId));
+    setSort((current) =>
+      current.kind === "rank" && current.appId === appId
+        ? { kind: "keyword", dir: "asc" }
+        : current
+    );
+  }, [setSort]);
+
+  const handleToggleKeyword = useCallback(
+    (keyword: string) => {
+      setSelectedKeywords((current) => {
+        if (current.includes(keyword)) {
+          return current.filter((k) => k !== keyword);
+        }
+        if (current.length >= COMPARE_MAX_KEYWORDS) return current;
+        return [...current, keyword];
+      });
+    },
+    []
+  );
+
+  const handleRemoveKeyword = useCallback((keyword: string) => {
+    setSelectedKeywords((current) => current.filter((k) => k !== keyword));
+  }, []);
+
+  const handleClearKeywords = useCallback(() => {
+    setSelectedKeywords([]);
+  }, []);
+
+  const handleSelectAllVisible = useCallback(() => {
+    setSelectedKeywords((current) => {
+      const next = new Set(current);
+      for (const kw of filteredUniverseKeywords) {
+        if (next.size >= COMPARE_MAX_KEYWORDS) break;
+        next.add(kw.keyword);
+      }
+      return dedupe(Array.from(next));
+    });
+  }, [filteredUniverseKeywords]);
+
+  const availableApps = useMemo(
+    () => apps.filter((app) => !selectedAppIds.includes(app.id)),
+    [apps, selectedAppIds]
+  );
+
+  const renderHeaderSortArrow = (active: boolean, dir: "asc" | "desc") => {
+    if (!active) return null;
+    return <span className="compare-sort-arrow">{dir === "asc" ? "▲" : "▼"}</span>;
+  };
+
+  return (
+    <div className="compare-shell">
+      <div className="compare-breadcrumb">
+        <span className="compare-breadcrumb-muted">KEYWORDS / </span>
+        <span>
+          COMPARE ({selectedAppIds.length} APPS, {selectedKeywords.length}{" "}
+          KEYWORDS)
+        </span>
+        <Button
+          id="compare-exit"
+          variant="ghost"
+          size="sm"
+          type="button"
+          onClick={onExit}
+        >
+          × Exit compare
+        </Button>
+      </div>
+
+      <Card className="compare-toolbar">
+        <div className="compare-chip-rail" aria-label="Selected apps">
+          {selectedApps.map((app) => {
+            const iconUrl = getIconUrl({
+              appId: app.id,
+              name: app.name,
+              icon: app.icon,
+            });
+            return (
+              <span key={app.id} className="compare-chip">
+                {iconUrl ? (
+                  <img
+                    className="compare-chip-icon"
+                    src={iconUrl}
+                    alt=""
+                    loading="lazy"
+                  />
+                ) : (
+                  <span className="compare-chip-initials" aria-hidden="true">
+                    {app.name.slice(0, 1).toUpperCase()}
+                  </span>
+                )}
+                <span className="compare-chip-label">{app.name}</span>
+                <button
+                  type="button"
+                  className="compare-chip-remove"
+                  aria-label={`Remove ${app.name}`}
+                  onClick={() => handleRemoveApp(app.id)}
+                  disabled={selectedAppIds.length <= COMPARE_MIN_APPS}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+          <div className="compare-chip-add" ref={appPickerRef}>
+            <Button
+              id="compare-add-app"
+              variant="outline"
+              size="sm"
+              type="button"
+              disabled={!canAddMoreApps || availableApps.length === 0}
+              onClick={() => setAppPickerOpen((v) => !v)}
+            >
+              + Add app
+            </Button>
+            {appPickerOpen ? (
+              <div className="compare-app-picker" role="listbox">
+                {availableApps.length === 0 ? (
+                  <div className="compare-app-picker-empty">
+                    No more apps to add.
+                  </div>
+                ) : (
+                  availableApps.map((app) => {
+                    const iconUrl = getIconUrl({
+                      appId: app.id,
+                      name: app.name,
+                      icon: app.icon,
+                    });
+                    return (
+                      <button
+                        key={app.id}
+                        type="button"
+                        className="compare-app-picker-row"
+                        onClick={() => {
+                          handleToggleApp(app.id);
+                          setAppPickerOpen(false);
+                        }}
+                      >
+                        {iconUrl ? (
+                          <img
+                            src={iconUrl}
+                            alt=""
+                            className="compare-chip-icon"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span
+                            className="compare-chip-initials"
+                            aria-hidden="true"
+                          >
+                            {app.name.slice(0, 1).toUpperCase()}
+                          </span>
+                        )}
+                        <span className="compare-chip-label">{app.name}</span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            ) : null}
+          </div>
+          <Badge className="compare-limit-badge">
+            {selectedAppIds.length} / {COMPARE_MAX_APPS} APPS
+          </Badge>
+        </div>
+
+        <div className="compare-keyword-controls">
+          <div className="compare-keyword-input-wrap">
+            <Input
+              id="compare-keyword-search"
+              type="text"
+              placeholder="Search keywords"
+              value={keywordSearch}
+              onChange={(event) => setKeywordSearch(event.target.value)}
+              aria-label="Search compare keywords"
+            />
+            <Button
+              id="compare-keyword-scope"
+              variant={showAllKeywords ? "outline" : "primary"}
+              size="sm"
+              type="button"
+              onClick={() => setShowAllKeywords((v) => !v)}
+            >
+              {showAllKeywords ? "ALL" : "TRACKED BY ALL"}
+            </Button>
+          </div>
+          <div className="compare-keyword-actions">
+            <Button
+              id="compare-keyword-select-all"
+              variant="ghost"
+              size="sm"
+              type="button"
+              disabled={!canAddMoreKeywords || filteredUniverseKeywords.length === 0}
+              onClick={handleSelectAllVisible}
+            >
+              Select all visible
+            </Button>
+            <Button
+              id="compare-keyword-clear"
+              variant="ghost"
+              size="sm"
+              type="button"
+              disabled={selectedKeywords.length === 0}
+              onClick={handleClearKeywords}
+            >
+              Clear
+            </Button>
+            <Badge className="compare-limit-badge">
+              {selectedKeywords.length} / {COMPARE_MAX_KEYWORDS} KEYWORDS
+            </Badge>
+          </div>
+        </div>
+
+        {universeError ? (
+          <p className="compare-error">{universeError}</p>
+        ) : null}
+
+        <div className="compare-universe" role="list">
+          {isUniverseLoading && !universe ? (
+            <div className="compare-universe-empty">Loading keywords…</div>
+          ) : filteredUniverseKeywords.length === 0 ? (
+            <div className="compare-universe-empty">
+              No keywords match. Try "ALL" or a different search.
+            </div>
+          ) : (
+            filteredUniverseKeywords.map((kw) => {
+              const isSelected = selectedKeywordSet.has(kw.keyword);
+              return (
+                <label
+                  key={kw.keyword}
+                  className={cx(
+                    "compare-universe-row",
+                    isSelected && "compare-universe-row--selected"
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => handleToggleKeyword(kw.keyword)}
+                    disabled={
+                      !isSelected &&
+                      selectedKeywords.length >= COMPARE_MAX_KEYWORDS
+                    }
+                  />
+                  <span className="compare-universe-kw">{kw.keyword}</span>
+                  <span className="compare-universe-meta">
+                    {kw.trackedCount}/{selectedAppIds.length} tracked
+                  </span>
+                  {kw.popularity != null ? (
+                    <span className="compare-universe-pop">
+                      pop {kw.popularity}
+                    </span>
+                  ) : null}
+                </label>
+              );
+            })
+          )}
+        </div>
+      </Card>
+
+      {(() => {
+        const matrixCard = (
+      <Card
+        className={cx(
+          "compare-matrix-card",
+          isMatrixFullscreen && "compare-matrix-card--fullscreen"
+        )}
+      >
+        <button
+          type="button"
+          className="compare-matrix-fullscreen"
+          aria-label={
+            isMatrixFullscreen ? "Exit fullscreen" : "Expand matrix to fullscreen"
+          }
+          aria-pressed={isMatrixFullscreen}
+          title={
+            isMatrixFullscreen
+              ? "Exit fullscreen (Esc)"
+              : "View matrix fullscreen"
+          }
+          onClick={() => setIsMatrixFullscreen((value) => !value)}
+        >
+          {isMatrixFullscreen ? "⤡" : "⛶"}
+        </button>
+        {matrixError ? (
+          <p className="compare-error">{matrixError}</p>
+        ) : null}
+        {selectedAppIds.length < COMPARE_MIN_APPS ? (
+          <div className="compare-empty">
+            Select at least {COMPARE_MIN_APPS} apps to start comparing.
+          </div>
+        ) : selectedKeywords.length === 0 ? (
+          <div className="compare-empty">
+            Pick at least one keyword to populate the matrix.
+          </div>
+        ) : isMatrixLoading && !matrix ? (
+          <div className="compare-empty">Building matrix…</div>
+        ) : !matrix || matrix.rows.length === 0 ? (
+          <div className="compare-empty">
+            No shared rank data yet. Try adding more keywords or toggling "ALL".
+          </div>
+        ) : (
+          <div className="compare-matrix-wrap">
+            <table className="compare-matrix">
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className={cx(
+                      "compare-matrix-keyword-head",
+                      sort.kind === "keyword" && "is-active"
+                    )}
+                  >
+                    <button
+                      type="button"
+                      className="compare-sort-button"
+                      onClick={() =>
+                        toggleSort({ kind: "keyword", dir: "asc" })
+                      }
+                    >
+                      Keyword
+                      {renderHeaderSortArrow(
+                        sort.kind === "keyword",
+                        sort.dir
+                      )}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    className={cx(
+                      "compare-matrix-meta-head",
+                      sort.kind === "popularity" && "is-active"
+                    )}
+                  >
+                    <button
+                      type="button"
+                      className="compare-sort-button"
+                      onClick={() =>
+                        toggleSort({ kind: "popularity", dir: "desc" })
+                      }
+                    >
+                      Popularity
+                      {renderHeaderSortArrow(
+                        sort.kind === "popularity",
+                        sort.dir
+                      )}
+                    </button>
+                  </th>
+                  {matrix.apps.map((app) => {
+                    const meta = appById.get(app.appId);
+                    const iconUrl = meta
+                      ? getIconUrl({
+                          appId: meta.id,
+                          name: meta.name,
+                          icon: meta.icon,
+                        })
+                      : null;
+                    return (
+                      <th
+                        key={app.appId}
+                        scope="col"
+                        className={cx(
+                          "compare-matrix-app-head",
+                          sort.kind === "rank" &&
+                            sort.appId === app.appId &&
+                            "is-active"
+                        )}
+                      >
+                        <button
+                          type="button"
+                          className="compare-sort-button compare-matrix-app-head-button"
+                          onClick={() =>
+                            toggleSort({
+                              kind: "rank",
+                              appId: app.appId,
+                              dir: "asc",
+                            })
+                          }
+                        >
+                          {iconUrl ? (
+                            <img
+                              className="compare-chip-icon"
+                              src={iconUrl}
+                              alt=""
+                              loading="lazy"
+                            />
+                          ) : null}
+                          <span className="compare-matrix-app-name">
+                            {app.name}
+                          </span>
+                          {renderHeaderSortArrow(
+                            sort.kind === "rank" && sort.appId === app.appId,
+                            sort.dir
+                          )}
+                        </button>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedRows.map((row) => (
+                  <tr key={row.normalizedKeyword}>
+                    <th scope="row" className="compare-matrix-keyword-cell">
+                      <span className="compare-matrix-keyword">
+                        {row.keyword}
+                      </span>
+                      <button
+                        type="button"
+                        className="compare-matrix-remove"
+                        aria-label={`Remove ${row.keyword}`}
+                        onClick={() => handleRemoveKeyword(row.keyword)}
+                      >
+                        ×
+                      </button>
+                      <span className="compare-matrix-universe-meta">
+                        {(() => {
+                          const uni = universeById.get(row.normalizedKeyword);
+                          if (!uni) return null;
+                          return `${uni.trackedCount}/${selectedAppIds.length} tracked`;
+                        })()}
+                      </span>
+                    </th>
+                    <td className="compare-matrix-meta-cell">
+                      {row.popularity != null ? row.popularity : "–"}
+                    </td>
+                    {row.cells.map((cell) => (
+                      <td
+                        key={cell.appId}
+                        className={cx(
+                          "compare-cell",
+                          rankTintClass(cell.currentPosition)
+                        )}
+                        title={describeCell(cell, row.status === "researched")}
+                        aria-label={describeCell(
+                          cell,
+                          row.status === "researched"
+                        )}
+                      >
+                        <CompareCellContent cell={cell} row={row} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+        );
+        return isMatrixFullscreen && typeof document !== "undefined"
+          ? createPortal(matrixCard, document.body)
+          : matrixCard;
+      })()}
+    </div>
+  );
+}

--- a/cli/dashboard-ui/hooks/use-compare.ts
+++ b/cli/dashboard-ui/hooks/use-compare.ts
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { apiGet, apiWrite, toActionableErrorMessage } from "../app-helpers";
+import type {
+  CompareKeywordsResponse,
+  CompareMatrixResponse,
+} from "../../shared/compare-types";
+
+const UNIVERSE_DEBOUNCE_MS = 150;
+const MATRIX_DEBOUNCE_MS = 250;
+const LOCALSTORAGE_KEY = "aso-compare-state";
+
+export type ComparePersistedState = {
+  appIds: string[];
+  keywords: string[];
+  sortBy?: CompareSort;
+  country?: string;
+  savedAt?: string;
+};
+
+export type CompareSort =
+  | { kind: "keyword"; dir: "asc" | "desc" }
+  | { kind: "popularity"; dir: "asc" | "desc" }
+  | { kind: "rank"; appId: string; dir: "asc" | "desc" };
+
+export function loadPersistedCompareState(): ComparePersistedState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(LOCALSTORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const record = parsed as Record<string, unknown>;
+    const appIds = Array.isArray(record.appIds)
+      ? record.appIds.filter((v): v is string => typeof v === "string")
+      : [];
+    const keywords = Array.isArray(record.keywords)
+      ? record.keywords.filter((v): v is string => typeof v === "string")
+      : [];
+    const sortBy = isValidSort(record.sortBy) ? (record.sortBy as CompareSort) : undefined;
+    const country = typeof record.country === "string" ? record.country : undefined;
+    return { appIds, keywords, sortBy, country };
+  } catch {
+    return null;
+  }
+}
+
+function isValidSort(value: unknown): value is CompareSort {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  if (record.dir !== "asc" && record.dir !== "desc") return false;
+  if (record.kind === "keyword" || record.kind === "popularity") return true;
+  if (record.kind === "rank" && typeof record.appId === "string") return true;
+  return false;
+}
+
+export function persistCompareState(state: ComparePersistedState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      LOCALSTORAGE_KEY,
+      JSON.stringify({ ...state, savedAt: new Date().toISOString() })
+    );
+  } catch {}
+}
+
+export function useCompareUniverse(
+  appIds: string[],
+  country: string,
+  enabled: boolean
+) {
+  const [data, setData] = useState<CompareKeywordsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorText, setErrorText] = useState("");
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      return;
+    }
+    if (appIds.length < 2) {
+      setData(null);
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsLoading(true);
+      setErrorText("");
+      const params = new URLSearchParams({
+        appIds: appIds.join(","),
+        country,
+      });
+      apiGet<CompareKeywordsResponse>(
+        `/api/aso/compare/keywords?${params.toString()}`
+      )
+        .then((response) => {
+          if (requestIdRef.current !== requestId) return;
+          setData(response);
+        })
+        .catch((error) => {
+          if (requestIdRef.current !== requestId) return;
+          setErrorText(
+            toActionableErrorMessage(error, "Failed to load keyword universe")
+          );
+          setData(null);
+        })
+        .finally(() => {
+          if (requestIdRef.current !== requestId) return;
+          setIsLoading(false);
+        });
+    }, UNIVERSE_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [appIds.join(","), country, enabled]);
+
+  return { universe: data, isUniverseLoading: isLoading, universeError: errorText };
+}
+
+export function useCompareMatrix(
+  appIds: string[],
+  keywords: string[],
+  country: string,
+  enabled: boolean
+) {
+  const [data, setData] = useState<CompareMatrixResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorText, setErrorText] = useState("");
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      return;
+    }
+    if (appIds.length < 2 || keywords.length < 1) {
+      setData(null);
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsLoading(true);
+      setErrorText("");
+      apiWrite<CompareMatrixResponse>("POST", "/api/aso/compare/matrix", {
+        appIds,
+        keywords,
+        country,
+      })
+        .then((response) => {
+          if (requestIdRef.current !== requestId) return;
+          setData(response);
+        })
+        .catch((error) => {
+          if (requestIdRef.current !== requestId) return;
+          setErrorText(
+            toActionableErrorMessage(error, "Failed to load compare matrix")
+          );
+          setData(null);
+        })
+        .finally(() => {
+          if (requestIdRef.current !== requestId) return;
+          setIsLoading(false);
+        });
+    }, MATRIX_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [appIds.join(","), keywords.join(","), country, enabled]);
+
+  return { matrix: data, isMatrixLoading: isLoading, matrixError: errorText };
+}
+
+export function useSortedMatrixRows(
+  matrix: CompareMatrixResponse | null,
+  sort: CompareSort
+): CompareMatrixResponse["rows"] {
+  return useMemo(() => {
+    if (!matrix) return [];
+    const rows = [...matrix.rows];
+    const dirMultiplier = sort.dir === "asc" ? 1 : -1;
+    const compareNumbers = (a: number | null, b: number | null): number => {
+      if (a === null && b === null) return 0;
+      if (a === null) return 1;
+      if (b === null) return -1;
+      return (a - b) * dirMultiplier;
+    };
+    const compareStrings = (a: string, b: string): number =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }) * dirMultiplier;
+    rows.sort((a, b) => {
+      if (sort.kind === "keyword") {
+        return compareStrings(a.keyword, b.keyword);
+      }
+      if (sort.kind === "popularity") {
+        return compareNumbers(a.popularity, b.popularity);
+      }
+      const aCell = a.cells.find((c) => c.appId === sort.appId);
+      const bCell = b.cells.find((c) => c.appId === sort.appId);
+      return compareNumbers(
+        aCell?.currentPosition ?? null,
+        bCell?.currentPosition ?? null
+      );
+    });
+    return rows;
+  }, [matrix, sort]);
+}
+
+const defaultSort: CompareSort = { kind: "keyword", dir: "asc" };
+
+export function useCompareSort(initial?: CompareSort) {
+  const [sort, setSort] = useState<CompareSort>(initial ?? defaultSort);
+  const toggleSort = useCallback((next: CompareSort) => {
+    setSort((current) => {
+      if (
+        current.kind === next.kind &&
+        (current.kind !== "rank" ||
+          (next.kind === "rank" && current.appId === next.appId))
+      ) {
+        return { ...current, dir: current.dir === "asc" ? "desc" : "asc" };
+      }
+      return next;
+    });
+  }, []);
+  return { sort, setSort, toggleSort };
+}

--- a/cli/dashboard-ui/styles.css
+++ b/cli/dashboard-ui/styles.css
@@ -287,6 +287,27 @@ body {
   text-transform: uppercase;
 }
 
+.apps-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-right: 6px;
+}
+
+.apps-section-header .apps-section-title {
+  margin: 4px 8px 8px;
+  flex: 1;
+}
+
+.apps-section-compare {
+  flex-shrink: 0;
+  padding: 2px 8px !important;
+  font-size: 10px !important;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .app-item {
   width: 100%;
   display: grid;
@@ -2611,4 +2632,528 @@ td.updated-value {
   text-align: center;
   font-size: 11px;
   color: color-mix(in oklab, var(--muted-foreground) 86%, var(--foreground));
+}
+
+.compare-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.compare-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+.compare-breadcrumb > span {
+  color: var(--foreground);
+}
+
+.compare-breadcrumb-muted {
+  color: var(--muted-foreground) !important;
+}
+
+.compare-breadcrumb .ui-btn {
+  margin-left: auto;
+}
+
+.compare-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+.compare-chip-rail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.compare-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+  font-size: 12px;
+}
+
+.compare-chip-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.compare-chip-initials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.compare-chip-label {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-chip-remove {
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.compare-chip-remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.compare-chip-add {
+  position: relative;
+}
+
+.compare-app-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 30;
+  min-width: 220px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 16px 40px rgb(0 0 0 / 40%);
+  padding: 4px;
+}
+
+.compare-app-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.compare-app-picker-row:hover {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
+.compare-app-picker-empty {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+.compare-limit-badge {
+  margin-left: auto;
+  background: color-mix(in oklab, var(--muted) 80%, transparent);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.compare-keyword-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.compare-keyword-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 320px;
+  min-width: 260px;
+}
+
+.compare-keyword-input-wrap .ui-input {
+  flex: 1;
+  font-size: 12px;
+  height: 28px;
+  padding: 4px 10px;
+}
+
+.compare-keyword-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.compare-toolbar .ui-btn--sm {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+}
+
+.compare-universe {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+}
+
+.compare-universe-empty {
+  grid-column: 1 / -1;
+  padding: 18px;
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.compare-universe-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.compare-universe-row:hover {
+  background: color-mix(in oklab, var(--primary) 6%, transparent);
+}
+
+.compare-universe-row--selected {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 40%, transparent);
+}
+
+.compare-universe-kw {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-universe-meta {
+  font-size: 10px;
+  color: var(--muted-foreground);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.compare-universe-pop {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--primary) 70%, var(--foreground));
+}
+
+.compare-error {
+  color: var(--destructive);
+  font-size: 12px;
+  margin: 0;
+}
+
+.compare-matrix-card {
+  padding: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.compare-matrix-fullscreen {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 4;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in oklab, var(--background) 78%, transparent);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
+}
+
+.compare-matrix-fullscreen:hover {
+  color: var(--foreground);
+  border-color: color-mix(in oklab, var(--primary) 60%, var(--border));
+  background: color-mix(in oklab, var(--primary) 10%, var(--background));
+}
+
+.compare-matrix-card--fullscreen {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100vw;
+  height: 100vh;
+  z-index: 1000;
+  border-radius: 0;
+  background: var(--background);
+  backdrop-filter: none;
+  box-shadow: none;
+  border: 0;
+  padding: 0;
+}
+
+.compare-matrix-card--fullscreen .compare-matrix-wrap {
+  max-height: 100vh;
+  height: 100vh;
+}
+
+.compare-empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+.compare-matrix-wrap {
+  overflow: auto;
+  max-height: calc(100vh - 320px);
+}
+
+.compare-matrix {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  font-family: inherit;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.compare-matrix thead th {
+  position: sticky;
+  top: 0;
+  background: color-mix(in oklab, var(--muted) 70%, var(--background));
+  border-bottom: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #787878;
+  z-index: 2;
+}
+
+.compare-matrix thead th.is-active {
+  color: var(--primary);
+}
+
+.compare-matrix-keyword-head {
+  left: 0;
+  z-index: 3 !important;
+  min-width: 200px;
+}
+
+.compare-matrix-meta-head {
+  min-width: 110px;
+}
+
+.compare-matrix-app-head {
+  min-width: 140px;
+}
+
+.compare-matrix-app-head-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.compare-matrix-app-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+  white-space: nowrap;
+}
+
+.compare-sort-button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.compare-sort-arrow {
+  font-size: 9px;
+  color: var(--primary);
+}
+
+.compare-matrix tbody tr:hover td,
+.compare-matrix tbody tr:hover th {
+  background: color-mix(in oklab, var(--primary) 5%, transparent);
+}
+
+.compare-matrix tbody th,
+.compare-matrix tbody td {
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  padding: 10px 12px;
+  vertical-align: middle;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.compare-matrix-keyword-cell {
+  position: sticky;
+  left: 0;
+  background: var(--background);
+  z-index: 1;
+  min-width: 200px;
+  text-align: left;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--foreground);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  row-gap: 2px;
+  column-gap: 8px;
+  align-items: center;
+}
+
+.compare-matrix-keyword {
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.compare-matrix-remove {
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.compare-matrix-remove:hover {
+  color: var(--destructive);
+}
+
+.compare-matrix-universe-meta {
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.compare-matrix-meta-cell {
+  color: var(--muted-foreground);
+}
+
+.compare-cell {
+  min-width: 140px;
+  padding: 10px 12px !important;
+  text-align: left;
+}
+
+.compare-cell-inner {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.compare-cell-rank {
+  font-size: 16px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.compare-cell-change {
+  font-size: 11px;
+  color: var(--muted-foreground);
+}
+
+.compare-cell-change--up {
+  color: color-mix(in oklab, var(--ok) 80%, var(--foreground));
+}
+
+.compare-cell-change--down {
+  color: var(--destructive);
+}
+
+.compare-cell-tracked-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--primary) 40%, transparent);
+}
+
+.compare-cell-mark {
+  color: var(--muted-foreground);
+  font-size: 14px;
+}
+
+.compare-cell--empty .compare-cell-mark {
+  opacity: 0.7;
+}
+
+.compare-cell--untracked {
+  opacity: 0.6;
+}
+
+.compare-cell--pending {
+  opacity: 0.6;
+}
+
+.compare-cell--tier-top {
+  background: color-mix(in oklab, var(--primary) 18%, transparent);
+}
+
+.compare-cell--tier-high {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
+.compare-cell--tier-mid {
+  background: color-mix(in oklab, var(--primary) 4%, transparent);
 }

--- a/cli/db/app-compare.test.ts
+++ b/cli/db/app-compare.test.ts
@@ -1,0 +1,191 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { closeDbForTests } from "./store";
+import { createAppKeywords, setPreviousPosition } from "./app-keywords";
+import { upsertKeywords } from "./aso-keywords";
+import { listUnionKeywords, getCompareMatrix } from "./app-compare";
+
+const TEST_DB_PATH = path.join(
+  os.tmpdir(),
+  `aso-app-compare-${process.pid}-${Date.now()}.sqlite`
+);
+
+function cleanDbFiles(): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      fs.unlinkSync(`${TEST_DB_PATH}${suffix}`);
+    } catch {}
+  }
+}
+
+function seedResearchedKeyword(
+  country: string,
+  keyword: string,
+  orderedAppIds: string[],
+  overrides: { popularity?: number; difficulty?: number | null } = {}
+): void {
+  upsertKeywords(country, [
+    {
+      keyword,
+      popularity: overrides.popularity ?? 50,
+      difficultyScore: overrides.difficulty ?? 40,
+      minDifficultyScore: null,
+      appCount: orderedAppIds.length,
+      keywordMatch: null,
+      orderedAppIds,
+      orderExpiresAt: "2099-01-01T00:00:00.000Z",
+    },
+  ]);
+}
+
+describe("app-compare", () => {
+  beforeAll(() => {
+    process.env.ASO_DB_PATH = TEST_DB_PATH;
+  });
+
+  beforeEach(() => {
+    closeDbForTests();
+    cleanDbFiles();
+  });
+
+  afterAll(() => {
+    closeDbForTests();
+    cleanDbFiles();
+    delete process.env.ASO_DB_PATH;
+  });
+
+  describe("listUnionKeywords", () => {
+    it("returns the union of tracked keywords across the requested apps", () => {
+      createAppKeywords("app1", ["shared", "only1"], "US");
+      createAppKeywords("app2", ["shared", "only2"], "US");
+      seedResearchedKeyword("US", "shared", ["app1", "app2"], {
+        popularity: 80,
+      });
+      seedResearchedKeyword("US", "only1", ["app1"], { popularity: 40 });
+      seedResearchedKeyword("US", "only2", ["app2"], { popularity: 60 });
+
+      const rows = listUnionKeywords(["app1", "app2"], "US");
+      const byKeyword = new Map(rows.map((r) => [r.keyword, r]));
+      expect(byKeyword.size).toBe(3);
+      const shared = byKeyword.get("shared");
+      expect(shared?.trackedCount).toBe(2);
+      expect(shared?.trackedByAppIds.slice().sort()).toEqual(["app1", "app2"]);
+      expect(shared?.popularity).toBe(80);
+      expect(shared?.isResearched).toBe(true);
+      const only1 = byKeyword.get("only1");
+      expect(only1?.trackedCount).toBe(1);
+      expect(only1?.trackedByAppIds).toEqual(["app1"]);
+    });
+
+    it("orders by tracked count desc, then popularity desc", () => {
+      createAppKeywords("app1", ["broad", "solo"], "US");
+      createAppKeywords("app2", ["broad"], "US");
+      seedResearchedKeyword("US", "broad", ["app1", "app2"], {
+        popularity: 30,
+      });
+      seedResearchedKeyword("US", "solo", ["app1"], { popularity: 90 });
+
+      const rows = listUnionKeywords(["app1", "app2"], "US");
+      expect(rows[0].keyword).toBe("broad");
+      expect(rows[1].keyword).toBe("solo");
+    });
+
+    it("marks keywords without aso_keywords row as not researched", () => {
+      createAppKeywords("app1", ["pending"], "US");
+      const rows = listUnionKeywords(["app1"], "US");
+      expect(rows).toHaveLength(1);
+      expect(rows[0].keyword).toBe("pending");
+      expect(rows[0].isResearched).toBe(false);
+      expect(rows[0].popularity).toBeNull();
+      expect(rows[0].difficulty).toBeNull();
+    });
+
+    it("scopes to country and ignores app_ids not requested", () => {
+      createAppKeywords("app1", ["scoped"], "US");
+      createAppKeywords("app2", ["scoped"], "US");
+      createAppKeywords("app1", ["scoped"], "GB");
+      const rows = listUnionKeywords(["app1"], "US");
+      expect(rows).toHaveLength(1);
+      expect(rows[0].trackedByAppIds).toEqual(["app1"]);
+    });
+
+    it("dedupes appId inputs and returns empty for empty input", () => {
+      createAppKeywords("app1", ["dup"], "US");
+      const deduped = listUnionKeywords(["app1", "app1", "", "  "], "US");
+      expect(deduped).toHaveLength(1);
+      expect(deduped[0].trackedByAppIds).toEqual(["app1"]);
+      expect(listUnionKeywords([], "US")).toEqual([]);
+    });
+  });
+
+  describe("getCompareMatrix", () => {
+    it("computes rank for apps even when they do not track the keyword", () => {
+      createAppKeywords("app1", ["halal"], "US");
+      seedResearchedKeyword("US", "halal", ["app1", "app2"], {
+        popularity: 70,
+      });
+      const rows = getCompareMatrix(["app1", "app2"], ["halal"], "US");
+      const byApp = new Map(rows.map((r) => [r.appId, r]));
+      expect(byApp.get("app1")?.currentPosition).toBe(1);
+      expect(byApp.get("app1")?.isTracked).toBe(true);
+      expect(byApp.get("app2")?.currentPosition).toBe(2);
+      expect(byApp.get("app2")?.isTracked).toBe(false);
+      expect(byApp.get("app1")?.isResearched).toBe(true);
+    });
+
+    it("returns null currentPosition when app is outside top 200 / not in ordered list", () => {
+      createAppKeywords("app1", ["kw"], "US");
+      seedResearchedKeyword("US", "kw", ["appX"], { popularity: 10 });
+      const rows = getCompareMatrix(["app1"], ["kw"], "US");
+      expect(rows[0].currentPosition).toBeNull();
+      expect(rows[0].isResearched).toBe(true);
+    });
+
+    it("marks not_researched when aso_keywords has no row", () => {
+      createAppKeywords("app1", ["pending"], "US");
+      const rows = getCompareMatrix(["app1"], ["pending"], "US");
+      expect(rows[0].isResearched).toBe(false);
+      expect(rows[0].currentPosition).toBeNull();
+      expect(rows[0].isTracked).toBe(true);
+    });
+
+    it("includes previous_position when app tracks the keyword", () => {
+      createAppKeywords("app1", ["rankkw"], "US");
+      setPreviousPosition("rankkw", "US", "app1", 12);
+      seedResearchedKeyword("US", "rankkw", ["otherApp", "app1"], {
+        popularity: 50,
+      });
+      const rows = getCompareMatrix(["app1"], ["rankkw"], "US");
+      expect(rows[0].previousPosition).toBe(12);
+      expect(rows[0].currentPosition).toBe(2);
+    });
+
+    it("normalizes keyword input and dedupes", () => {
+      createAppKeywords("app1", ["clean"], "US");
+      seedResearchedKeyword("US", "clean", ["app1"], { popularity: 42 });
+      const rows = getCompareMatrix(
+        ["app1", "app1"],
+        ["  CLEAN  ", "Clean", "clean"],
+        "US"
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].appId).toBe("app1");
+      expect(rows[0].normalizedKeyword).toBe("clean");
+      expect(rows[0].currentPosition).toBe(1);
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(getCompareMatrix([], ["kw"], "US")).toEqual([]);
+      expect(getCompareMatrix(["app1"], [], "US")).toEqual([]);
+    });
+
+    it("handles empty ordered_app_ids gracefully", () => {
+      createAppKeywords("app1", ["empty"], "US");
+      seedResearchedKeyword("US", "empty", [], { popularity: 5 });
+      const rows = getCompareMatrix(["app1"], ["empty"], "US");
+      expect(rows[0].currentPosition).toBeNull();
+      expect(rows[0].isResearched).toBe(true);
+    });
+  });
+});

--- a/cli/db/app-compare.ts
+++ b/cli/db/app-compare.ts
@@ -1,0 +1,203 @@
+import { getDb } from "./store";
+import {
+  DEFAULT_ASO_COUNTRY,
+  normalizeKeyword,
+} from "../domain/keywords/policy";
+
+const COUNTRY = DEFAULT_ASO_COUNTRY;
+
+export type CompareUniverseRow = {
+  keyword: string;
+  normalizedKeyword: string;
+  trackedByAppIds: string[];
+  trackedCount: number;
+  popularity: number | null;
+  difficulty: number | null;
+  isResearched: boolean;
+};
+
+export type CompareMatrixRow = {
+  appId: string;
+  keyword: string;
+  normalizedKeyword: string;
+  popularity: number | null;
+  difficulty: number | null;
+  isResearched: boolean;
+  currentPosition: number | null;
+  previousPosition: number | null;
+  isTracked: boolean;
+};
+
+type UniverseSqlRow = {
+  keyword: string;
+  tracked_app_ids_csv: string | null;
+  tracked_count: number;
+  popularity: number | null;
+  difficulty: number | null;
+  is_researched: number;
+};
+
+type MatrixSqlRow = {
+  app_id: string;
+  keyword: string;
+  normalized: string;
+  popularity: number | null;
+  difficulty: number | null;
+  is_researched: number;
+  current_position: number | null;
+  previous_position: number | null;
+  is_tracked: number;
+};
+
+function dedupeNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function dedupeNormalizedKeywords(values: string[]): Array<{
+  raw: string;
+  normalized: string;
+}> {
+  const seen = new Set<string>();
+  const out: Array<{ raw: string; normalized: string }> = [];
+  for (const value of values) {
+    const normalized = normalizeKeyword(value);
+    if (!normalized) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push({ raw: value.trim(), normalized });
+  }
+  return out;
+}
+
+export function listUnionKeywords(
+  appIds: string[],
+  country: string = COUNTRY
+): CompareUniverseRow[] {
+  const dedupedAppIds = dedupeNonEmpty(appIds);
+  if (dedupedAppIds.length === 0) return [];
+  const db = getDb();
+  const appPlaceholders = dedupedAppIds.map(() => "?").join(", ");
+  const sql = `
+    SELECT
+      ak.keyword AS keyword,
+      GROUP_CONCAT(ak.app_id, ',') AS tracked_app_ids_csv,
+      COUNT(DISTINCT ak.app_id) AS tracked_count,
+      k.popularity AS popularity,
+      k.difficulty_score AS difficulty,
+      CASE WHEN k.normalized_keyword IS NULL THEN 0 ELSE 1 END AS is_researched
+    FROM app_keywords ak
+    LEFT JOIN aso_keywords k
+      ON k.normalized_keyword = ak.keyword
+     AND k.country = ak.country
+    WHERE ak.app_id IN (${appPlaceholders})
+      AND ak.country = ?
+    GROUP BY ak.keyword
+    ORDER BY tracked_count DESC,
+             (k.popularity IS NULL) ASC,
+             k.popularity DESC,
+             ak.keyword COLLATE NOCASE ASC
+  `;
+  const rows = db
+    .prepare(sql)
+    .all(...dedupedAppIds, country) as UniverseSqlRow[];
+  const requestedAppIdSet = new Set(dedupedAppIds);
+  return rows.map((row) => {
+    const trackedByAppIds = (row.tracked_app_ids_csv ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value): value is string => value.length > 0)
+      .filter((appId) => requestedAppIdSet.has(appId));
+    const uniqueTracked = Array.from(new Set(trackedByAppIds));
+    return {
+      keyword: row.keyword,
+      normalizedKeyword: row.keyword,
+      trackedByAppIds: uniqueTracked,
+      trackedCount: uniqueTracked.length,
+      popularity: row.popularity,
+      difficulty: row.difficulty,
+      isResearched: row.is_researched === 1,
+    };
+  });
+}
+
+export function getCompareMatrix(
+  appIds: string[],
+  keywords: string[],
+  country: string = COUNTRY
+): CompareMatrixRow[] {
+  const dedupedAppIds = dedupeNonEmpty(appIds);
+  const dedupedKeywords = dedupeNormalizedKeywords(keywords);
+  if (dedupedAppIds.length === 0 || dedupedKeywords.length === 0) return [];
+  const db = getDb();
+  const appValues = dedupedAppIds.map(() => "(?)").join(", ");
+  const kwValues = dedupedKeywords.map(() => "(?, ?)").join(", ");
+  const sql = `
+    WITH
+      selected_apps(app_id) AS (VALUES ${appValues}),
+      selected_kws(keyword, normalized) AS (VALUES ${kwValues}),
+      kw_meta AS (
+        SELECT
+          sk.keyword AS keyword,
+          sk.normalized AS normalized,
+          k.popularity AS popularity,
+          k.difficulty_score AS difficulty,
+          k.ordered_app_ids AS ordered_app_ids,
+          CASE WHEN k.normalized_keyword IS NULL THEN 0 ELSE 1 END AS is_researched
+        FROM selected_kws sk
+        LEFT JOIN aso_keywords k
+          ON k.normalized_keyword = sk.normalized
+         AND k.country = ?
+      )
+    SELECT
+      sa.app_id AS app_id,
+      km.keyword AS keyword,
+      km.normalized AS normalized,
+      km.popularity AS popularity,
+      km.difficulty AS difficulty,
+      km.is_researched AS is_researched,
+      (
+        SELECT CAST(je.key AS INTEGER) + 1
+        FROM json_each(COALESCE(km.ordered_app_ids, '[]')) AS je
+        WHERE je.value = sa.app_id
+        LIMIT 1
+      ) AS current_position,
+      ak.previous_position AS previous_position,
+      CASE WHEN ak.app_id IS NULL THEN 0 ELSE 1 END AS is_tracked
+    FROM selected_apps sa
+    CROSS JOIN kw_meta km
+    LEFT JOIN app_keywords ak
+      ON ak.app_id = sa.app_id
+     AND ak.keyword = km.normalized
+     AND ak.country = ?
+    ORDER BY km.normalized ASC, sa.app_id ASC
+  `;
+  const params: unknown[] = [];
+  for (const appId of dedupedAppIds) params.push(appId);
+  for (const { raw, normalized } of dedupedKeywords) {
+    params.push(raw);
+    params.push(normalized);
+  }
+  params.push(country);
+  params.push(country);
+  const rows = db.prepare(sql).all(...params) as MatrixSqlRow[];
+  return rows.map((row) => ({
+    appId: row.app_id,
+    keyword: row.keyword,
+    normalizedKeyword: row.normalized,
+    popularity: row.popularity,
+    difficulty: row.difficulty,
+    isResearched: row.is_researched === 1,
+    currentPosition: row.current_position,
+    previousPosition: row.previous_position,
+    isTracked: row.is_tracked === 1,
+  }));
+}

--- a/cli/shared/compare-types.ts
+++ b/cli/shared/compare-types.ts
@@ -1,0 +1,55 @@
+export const COMPARE_MIN_APPS = 2;
+export const COMPARE_MAX_APPS = 10;
+export const COMPARE_MIN_KEYWORDS = 1;
+export const COMPARE_MAX_KEYWORDS = 100;
+
+export type CompareApp = {
+  appId: string;
+  name: string;
+};
+
+export type CompareUniverseKeyword = {
+  keyword: string;
+  normalizedKeyword: string;
+  trackedByAppIds: string[];
+  trackedCount: number;
+  popularity: number | null;
+  difficulty: number | null;
+  isResearched: boolean;
+};
+
+export type CompareKeywordsResponse = {
+  country: string;
+  apps: CompareApp[];
+  keywords: CompareUniverseKeyword[];
+};
+
+export type CompareMatrixRequest = {
+  appIds: string[];
+  keywords: string[];
+  country?: string;
+};
+
+export type CompareMatrixCell = {
+  appId: string;
+  currentPosition: number | null;
+  previousPosition: number | null;
+  change: number | null;
+  isTracked: boolean;
+};
+
+export type CompareMatrixRow = {
+  keyword: string;
+  normalizedKeyword: string;
+  popularity: number | null;
+  difficulty: number | null;
+  status: "researched" | "not_researched";
+  cells: CompareMatrixCell[];
+};
+
+export type CompareMatrixResponse = {
+  country: string;
+  generatedAt: string;
+  apps: CompareApp[];
+  rows: CompareMatrixRow[];
+};

--- a/docs/aso-runtime-flows.md
+++ b/docs/aso-runtime-flows.md
@@ -22,6 +22,7 @@ Runtime flow contracts across CLI commands, local dashboard API, and ASO service
 - `aso reset-credentials`: clear saved ASO keychain credentials and local cookies.
 - MCP `aso_evaluate_keywords`: accept explicit keywords (max 100), run `aso keywords "<comma-separated-keywords>" --stdout`, return evaluated keyword results.
 - Dashboard API mutations: app add (single-item POST; UI may batch multiple selections), app delete, keyword add/delete, keyword favorite toggle, auth start.
+- Dashboard API reads (compare): `GET /api/aso/compare/keywords?appIds=...` returns the union of keywords tracked across the selected apps with coverage metadata; `POST /api/aso/compare/matrix` returns a per-(app, keyword) rank matrix derived from `aso_keywords.ordered_app_ids`. Both are read-only and do not touch `keywordPipelineService` or `keywordWriteRepository`.
 
 ## Boundary Ownership
 - Domain policy (`cli/domain/keywords/*`, `cli/domain/errors/*`) is shared across CLI/server/UI for country guardrails, keyword normalization, limits, and dashboard-safe error/message mapping.
@@ -33,6 +34,7 @@ Runtime flow contracts across CLI commands, local dashboard API, and ASO service
   - request/response helpers (`http-utils.ts`)
   - apps handlers (`apps-handler.ts`)
   - keyword/app-doc handlers (`routes/keyword-handlers.ts`, `routes/app-doc-handlers.ts`)
+  - compare handlers (`routes/compare-handlers.ts`) backed by read-only helpers in `cli/db/app-compare.ts`
   - static assets (`static-files.ts`)
 
 ## Flow A: CLI Keyword Fetch


### PR DESCRIPTION
## Summary

Adds a **Compare Apps** view to the ASO dashboard so users can evaluate how multiple apps stack up against each other for a chosen set of keywords, side by side.

Context and discussion: #2

## Problem

Today the dashboard only surfaces keyword popularity/difficulty/rank for a single selected app at a time. There is no way to ask questions like *"Where do my three competitors and I stand on this keyword set?"* or *"Which keywords am I leading on vs. trailing?"* without manually switching apps and mentally diffing columns.

## Solution

A new compare mode, reachable from a **Compare** button next to the sidebar *Apps* heading. It presents a matrix (keywords × apps) with ranks, rank change deltas, rank-tier color bands, and clear distinctions between *not tracked*, *outside top 200*, and *not yet researched*.

Ranks are derived from the existing `aso_keywords.ordered_app_ids` top-200 list, which means:
- No schema changes.
- An app's rank is available for any keyword it appears in the global top 200, even if the app itself has not added that keyword to its tracked list.

## Features

- **Multi-app comparison** — pick 2 to 10 owned apps from a chip rail + dropdown picker.
- **Custom keyword selection** — pick 1 to 100 keywords from the union of keywords the selected apps track, with *tracked by all* / *any* scoping and free-text search.
- **Live-updating matrix** — changes to apps or keywords re-fetch the matrix (debounced) and re-render in place.
- **Per-column sorting** — sort by keyword, popularity, or any app's rank column.
- **Inline chip removal** — remove an app or keyword straight from the matrix row/column header.
- **Fullscreen mode** — expand the matrix to the full viewport (⛶ icon, ESC to exit).
- **Persistence** — last selection (apps, keywords, sort) is stored in localStorage and restored on reopen.
- **Three distinct empty-cell states** — *not tracked by app*, *outside top 200*, *not yet researched*, each with tooltip + aria-label.

## Implementation notes

- Read-only endpoints, consistent with existing route factory pattern:
  - `GET /api/aso/compare/keywords` — keyword universe with coverage metadata.
  - `POST /api/aso/compare/matrix` — per-`(app, keyword)` cell data.
- SQL uses a single query per endpoint with `json_each` to look up positions in `ordered_app_ids`, mirroring the existing paged keyword handler.
- Frontend is a single `CompareView` component + `use-compare` hook (universe fetch, matrix fetch, persistence). `App.tsx` gets a small button + conditional render — no structural rewrite.
- Fullscreen uses a React portal to `document.body` to bypass a containing-block issue caused by an identity `transform` on the app shell.
- Styling reuses existing primitives (`Button`, `Input`, `Badge`, `Card`) and aligns with the main keyword table's typography (10px uppercase headers, 12px body, JetBrains Mono throughout).

## Boundaries respected

- No changes to `keywordPipelineService` or `keywordWriteRepository` (compare is read-only).
- No changes to `aso_keywords`, `app_keywords`, or any other table schema.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test -- --watchman=false` — 393 passing (12 new in `cli/db/app-compare.test.ts`)
- [x] `npm run build` — builds CLI, MCP, and dashboard bundles
- [x] Manual E2E via `node cli/dist/cli.js` + browser:
  - [x] Open compare from sidebar, default selection pre-populated
  - [x] Add/remove apps, matrix updates live
  - [x] Sort by any app column
  - [x] Fullscreen expand/collapse (button + ESC)
  - [x] Reload — localStorage restores selection
  - [x] Tooltip/aria messages for each empty-cell state

## Docs

- `docs/aso-runtime-flows.md` — new read-only compare endpoints documented under *Trigger Map* and *Boundary Ownership*.
- `README.md` — added a one-line feature bullet.

## Scope

Explicitly out of scope for v1 (happy to scope these as follow-ups based on feedback):
- Shareable URL state / named saved comparisons
- CSV or Markdown export
- Sparkline / historical trend per cell

Thanks for building this tool — happy to adjust scope, API shape, or integration approach based on your feedback.