### PR TITLE
Reorder keyword table columns and relax header typography

### DIFF
--- a/cli/dashboard-ui/App.tsx
+++ b/cli/dashboard-ui/App.tsx
@@ -2399,36 +2399,6 @@ export function App() {
                       {renderFilterDropdown("difficulty", "Difficulty")}
                     </div>
                   </th>
-                  <th
-                    className="col-middle"
-                    data-sort-key="brand"
-                  >
-                    <div className="column-filter-header">
-                      <span className="sort-label">
-                        <span>Brand</span>
-                      </span>
-                      {renderFilterDropdown("brand", "Brand")}
-                    </div>
-                  </th>
-                  <th
-                    className="col-middle"
-                    data-sort-key="favorite"
-                  >
-                    <div className="column-filter-header">
-                      <span className="sort-label">
-                        <span>Favorite</span>
-                      </span>
-                      {renderFilterDropdown("favorite", "Favorite")}
-                    </div>
-                  </th>
-                  <th
-                    className={`num col-middle sortable ${sortBy === "appCount" ? "active" : ""}`}
-                    data-sort-key="appCount"
-                    aria-sort={sortBy === "appCount" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
-                    onClick={() => onSortHeader("appCount")}
-                  >
-                    {renderSortLabel("appCount")}
-                  </th>
                   {showRankingColumns ? (
                     <>
                       <th
@@ -2461,6 +2431,36 @@ export function App() {
                       </th>
                     </>
                   ) : null}
+                  <th
+                    className="col-middle"
+                    data-sort-key="brand"
+                  >
+                    <div className="column-filter-header">
+                      <span className="sort-label">
+                        <span>Brand</span>
+                      </span>
+                      {renderFilterDropdown("brand", "Brand")}
+                    </div>
+                  </th>
+                  <th
+                    className="col-middle"
+                    data-sort-key="favorite"
+                  >
+                    <div className="column-filter-header">
+                      <span className="sort-label">
+                        <span>Favorite</span>
+                      </span>
+                      {renderFilterDropdown("favorite", "Favorite")}
+                    </div>
+                  </th>
+                  <th
+                    className={`num col-middle sortable ${sortBy === "appCount" ? "active" : ""}`}
+                    data-sort-key="appCount"
+                    aria-sort={sortBy === "appCount" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
+                    onClick={() => onSortHeader("appCount")}
+                  >
+                    {renderSortLabel("appCount")}
+                  </th>
                   <th
                     className={`sortable ${sortBy === "updatedAt" ? "active" : ""}`}
                     data-sort-key="updatedAt"
@@ -2508,25 +2508,6 @@ export function App() {
                             ? "Calculating..."
                             : Math.round(row.difficultyScore)}
                       </td>
-                      <td className="col-middle">
-                        {row.isBrandKeyword ? "✓" : "-"}
-                      </td>
-                      <td className="col-middle favorite-column">
-                        <button
-                          type="button"
-                          className={`favorite-heart-button ${row.isFavorite ? "is-favorite" : ""}`}
-                          aria-label={`${row.isFavorite ? "Unfavorite" : "Favorite"} keyword ${row.keyword}`}
-                          aria-pressed={row.isFavorite}
-                          disabled={favoriteMutationKeywords.has(row.keyword)}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            void onToggleKeywordFavorite(row.keyword, !row.isFavorite);
-                          }}
-                        >
-                          <HeartIcon filled={row.isFavorite} />
-                        </button>
-                      </td>
-                      <td className="num col-middle">{row.appCount ?? "-"}</td>
                       {showRankingColumns ? (
                         <>
                           <td className="num col-middle">
@@ -2569,6 +2550,25 @@ export function App() {
                           </td>
                         </>
                       ) : null}
+                      <td className="col-middle">
+                        {row.isBrandKeyword ? "✓" : "-"}
+                      </td>
+                      <td className="col-middle favorite-column">
+                        <button
+                          type="button"
+                          className={`favorite-heart-button ${row.isFavorite ? "is-favorite" : ""}`}
+                          aria-label={`${row.isFavorite ? "Unfavorite" : "Favorite"} keyword ${row.keyword}`}
+                          aria-pressed={row.isFavorite}
+                          disabled={favoriteMutationKeywords.has(row.keyword)}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void onToggleKeywordFavorite(row.keyword, !row.isFavorite);
+                          }}
+                        >
+                          <HeartIcon filled={row.isFavorite} />
+                        </button>
+                      </td>
+                      <td className="num col-middle">{row.appCount ?? "-"}</td>
                       <td className="updated-value">
                         {formatDate(row.updatedAt, displayLocale)}
                       </td>

--- a/cli/dashboard-ui/app.interactions.test.tsx
+++ b/cli/dashboard-ui/app.interactions.test.tsx
@@ -409,7 +409,7 @@ describe("dashboard app interactions", () => {
 
     const keywordCell = await screen.findByText("meditation");
     const row = keywordCell.closest("tr") as HTMLElement;
-    const rankCell = within(row).getAllByRole("cell")[6];
+    const rankCell = within(row).getAllByRole("cell")[3];
     const rankTrigger = within(rankCell).getByRole("button", { name: "4" });
     fireEvent.click(rankTrigger);
 

--- a/cli/dashboard-ui/styles.css
+++ b/cli/dashboard-ui/styles.css
@@ -2187,8 +2187,8 @@ th {
   color: #787878;
   font-weight: 600;
   font-size: 10px;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  text-transform: none;
   background: var(--bg-1);
   border-bottom: 2px solid var(--divider);
 }


### PR DESCRIPTION
### Motivation
- Improve the visual and logical ordering of the keyword table so ranking columns are shown before Brand/Favorite/App Count when ranking data is available. 
- Make table header typography less aggressive by reducing letter spacing and disabling forced uppercase to improve readability.

### Description
- Reordered the table header and row cells in `cli/dashboard-ui/App.tsx` so `Brand`, `Favorite`, and `App Count` are rendered after the optional `rank`/`change` columns. 
- Updated the row rendering to keep the favorite toggle behavior and app count display intact after the column move. 
- Adjusted table header styles in `cli/dashboard-ui/styles.css` by setting `letter-spacing: 0.01em` and `text-transform: none`.

### Testing
- Built the frontend with `yarn build` which completed successfully. 
- Ran the frontend unit test suite with `yarn test`, which passed. 
- Ran the linter with `yarn lint`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14248230c48330a2e025c9d7ecbf7b)